### PR TITLE
feat: 日本語文字列処理とアラート機能の改善

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface Reminder {
   completed: boolean;
   notes?: string;
   due_date?: string; // ISO 8601 format
+  alert_date?: string; // ISO 8601 format - When to show notification (remind me date)
   creation_date: string; // ISO 8601 format
   priority?: string; // 'none', 'low', 'medium', 'high'
   list_name: string;
@@ -30,6 +31,7 @@ export interface CreateReminderParams {
   name: string;
   notes?: string;
   due_date?: string; // ISO 8601 format
+  alert_date?: string; // ISO 8601 format - When to show notification (remind me date)
   priority?: 'none' | 'low' | 'medium' | 'high';
 }
 
@@ -69,6 +71,7 @@ export interface BaseResult {
 
 export interface CreateReminderResult extends BaseResult {
   reminder_id?: string;
+  warning?: string;
 }
 
 export interface CompleteReminderResult extends BaseResult {}


### PR DESCRIPTION
## Summary

- AppleScriptの日本語文字列処理エラーを修正
- 早期アラート機能の制限について詳細な警告メッセージを追加
- AppleScript APIの制限を詳細ドキュメント化

## 主な変更点

### 🔧 AppleScript日本語文字列処理の修正
- `osascript -e`から一時ファイル方式に変更
- UTF-8エンコーディングサポート強化
- 適切なファイルクリーンアップ処理を追加

### ⚠️ 早期アラート制限の対応
- AppleScriptでは`due date`と`remind me date`が連動する制限を発見
- 期日より前のアラート設定時に自動警告メッセージを追加
- 代替案として複数リマインダー作成パターンを提案

### 📚 ドキュメント改善
- 既知の制限セクションを`CLAUDE.md`に追加
- 早期アラートと繰り返し設定の制限を明記
- 実用的な代替案を提示

## Test plan

- [x] 日本語文字列でのリマインダー作成/削除が正常動作
- [x] 早期アラート設定時に適切な警告メッセージが表示
- [x] 全単体テストが通過（43 passed）
- [x] AppleScript一時ファイル方式でUTF-8処理が正常動作

## Breaking Changes

なし - 既存のAPIは後方互換性を維持

🤖 Generated with [Claude Code](https://claude.ai/code)