### PR TITLE
ci: Bump codecov/codecov-action from v5 to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       continue-on-error: true  # Temporarily allow coverage failures until we add more tests
 
     - name: Upload coverage reports
-      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage/lcov.info


### PR DESCRIPTION
## Summary
- codecov/codecov-action を v5.5.4 から v6.0.0 に更新
- #85 のコンフリクト解消版

Closes #85

## Test plan
- [x] `npm run build` 通過
- [x] `npm run lint` 通過
- [x] `npm test` 通過 (58 passed, 9 skipped)