### PR TITLE
fix(ci): auto-fix CI Auto Repair failure

### DIFF
--- a/.github/workflows/ci-auto-repair.yml
+++ b/.github/workflows/ci-auto-repair.yml
@@ -41,6 +41,12 @@ jobs:
               pull_number: pr.number
             });
 
+            if (pullRequest.state !== 'open') {
+              console.log(`PR #${pr.number} is ${pullRequest.state}; skipping auto-repair`);
+              core.setOutput('has_pr', false);
+              return;
+            }
+
             const isDependabot = [
               'dependabot[bot]', 'app/dependabot',
               'renovate[bot]', 'renovate-bot'


### PR DESCRIPTION
## Automated CI Fix

**Workflow**: CI Auto Repair
**Failed Run**: https://github.com/atani/mcp-server-macos-reminders/actions/runs/25590574018

### What was fixed
Skip the auto-repair workflow when the associated PR is already closed or merged, so it no longer tries to checkout a deleted Dependabot branch.

---
*Auto-generated by OpenClaw ci-autofix skill. Please review before merging.*